### PR TITLE
use C/C++ time libraries instead of DateTime class

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,25 @@ Update/setup an RTC module from a [NTP][] service using with ESP8266 module.
     - [JSON library][ArduinoJson] + SPIFFS
     - [WiFiManager library][WiFiManager]
 
-## Get libs in PlatformIO
+## Get libs in PlatformIO CLI
 ```bash
-pio lib install EasyNTPClient RTClib
+pio lib install RTClib
 ```
+
+## Compile in PlatformIO CLI
+```bash
+# set wifi credentials
+export WIFI_SSID=myWIFIssid WIFI_PASS=myWIFIpass
+
+# compile & upload for d1_mini (esp8266)
+pio run -e d1_mini
+pio run -e d1_mini  -t upload
+
+# compile & upload for d1_mini (esp32)
+pio run -e mhetesp32minikit
+pio run -e mhetesp32minikit  -t upload
+```
+
 
 
 [d1_mini]: https://wiki.wemos.cc/products:d1:d1_mini

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Update/setup an RTC module from a [NTP][] service using with ESP8266 module.
     - enclosure
 - Software
   - arduino framework
-  - core/HAL ESP8266/ESP32 and time C/C++ libraries (see #4)
+  - core/HAL ESP8266/ESP32 and C/C++ time libraries (see #4)
   - strip down RTC library (see #2)
   - manage wifi keys (optional)
     - [JSON library][ArduinoJson] + SPIFFS

--- a/README.md
+++ b/README.md
@@ -13,16 +13,11 @@ Update/setup an RTC module from a [NTP][] service using with ESP8266 module.
     - enclosure
 - Software
   - arduino framework
-  - core/HAL ESP8266/ESP32 time library
-  - [RTClib library][RTClib]
+  - core/HAL ESP8266/ESP32 and time C/C++ libraries (see #4)
+  - strip down RTC library (see #2)
   - manage wifi keys (optional)
     - [JSON library][ArduinoJson] + SPIFFS
     - [WiFiManager library][WiFiManager]
-
-## Get libs in PlatformIO CLI
-```bash
-pio lib install RTClib
-```
 
 ## Compile in PlatformIO CLI
 ```bash
@@ -31,14 +26,12 @@ export WIFI_SSID=myWIFIssid WIFI_PASS=myWIFIpass
 
 # compile & upload for d1_mini (esp8266)
 pio run -e d1_mini
-pio run -e d1_mini  -t upload
+pio run -e d1_mini -t upload
 
-# compile & upload for d1_mini (esp32)
+# compile & upload for mhetesp32minikit (esp32)
 pio run -e mhetesp32minikit
-pio run -e mhetesp32minikit  -t upload
+pio run -e mhetesp32minikit -t upload
 ```
-
-
 
 [d1_mini]: https://wiki.wemos.cc/products:d1:d1_mini
 [oled_shield]: https://wiki.wemos.cc/products:d1_mini_shields:oled_shield
@@ -47,7 +40,6 @@ pio run -e mhetesp32minikit  -t upload
 [base2]: https://wiki.wemos.cc/products:d1_mini_shields:dual_base
 [base3]: https://wiki.wemos.cc/products:d1_mini_shields:tripler_base
 
-[RTClib]: https://github.com/adafruit/RTClib
 [OLEDlib]: https://github.com/squix78/esp8266-oled-ssd1306
 [WiFiManager]: https://github.com/tzapu/WiFiManager.git
 [ArduinoJson]: https://github.com/bblanchon/ArduinoJson.git

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,11 +9,13 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [platformio]
-env_default = d1_mini, mhetesp32minikit
+env_default = d1_mini
 
 [common]
-build_flags = -DTIME_ZONE=TIME_UTC -DWIFI_SSID=\"your_ssid\" -DWIFI_PASS=\"your_pass\"
-lib_deps = RTClib
+build_flags =
+  -DTIME_ZONE=TIME_UTC
+  -DWIFI_SSID=\"${env.WIFI_SSID}\"
+  -DWIFI_PASS=\"${env.WIFI_PASS}\"
 
 [env:d1_mini]
 platform = espressif8266

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,17 +9,17 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [platformio]
-env_default = mhetesp32minikit
+env_default = d1_mini
 
 [common]
 build_flags =
-  -DDEBUG
   -DTIME_ZONE=TIME_UTC
   -DWIFI_SSID=\"${env.WIFI_SSID}\"
   -DWIFI_PASS=\"${env.WIFI_PASS}\"
+; -DDEBUG
 
 [env:d1_mini]
-platform = espressif8266
+platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
 board = d1_mini
 framework = arduino
 build_flags = ${common.build_flags}
@@ -31,7 +31,7 @@ framework = arduino
 build_flags = ${common.build_flags}
 
 [env:esp01]
-platform = espressif8266
+platform = https://github.com/platformio/platform-espressif8266.git#feature/stage
 board = esp01
 framework = arduino
 build_flags = ${common.build_flags}

--- a/platformio.ini
+++ b/platformio.ini
@@ -9,10 +9,11 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [platformio]
-env_default = d1_mini
+env_default = mhetesp32minikit
 
 [common]
 build_flags =
+  -DDEBUG
   -DTIME_ZONE=TIME_UTC
   -DWIFI_SSID=\"${env.WIFI_SSID}\"
   -DWIFI_PASS=\"${env.WIFI_PASS}\"

--- a/src/ESPntp2rtc.ino
+++ b/src/ESPntp2rtc.ino
@@ -8,14 +8,18 @@ Based on example code from
 */
 
 #include <Wire.h>
-#include <RTClib.h>
-RTC_DS1307  ds1307;
-RTC_PCF8523 pcf8523;
-
 #include <SSD1306.h>            // alias for `#include "SSD1306Wire.h"`
 #include "images.h"             // WiFi logo
 SSD1306  display(0x3c, SDA, SCL); // Initialize the OLED display using Wire library
 
+#include <RTC.h>
+RTC ds1307(rtc_t::DS1307);
+RTC ds3231(rtc_t::DS3231);
+RTC pcf8523(rtc_t::PCF8523);
+RTC pcf8563(rtc_t::PCF8563);
+
+#define SECONDS_FROM_1900_TO_1970 2208988800L
+#define SECONDS_FROM_1970_TO_2000  946684800L
 #ifdef ARDUINO_ARCH_ESP32
  #include <WiFi.h>
 #elif defined(ESP8266)
@@ -23,13 +27,6 @@ SSD1306  display(0x3c, SDA, SCL); // Initialize the OLED display using Wire libr
 #endif
 #include <time.h>
 #include "config.h"
-
-#define DEBUG
-#ifdef DEBUG
- #define debug(f,s,d) Serial.printf(f,s,d)
-#else
- #define debug(f,s,d) //skip this line
-#endif
 
 void setup() {
   Serial.begin(115200);
@@ -56,83 +53,67 @@ void setup() {
     }
     delay(1000);
   }
-  Serial.printf("WiFi connected\n");
+  Serial.printf("\nWiFi connected\n");
 
-  Serial.printf("Connecting to %s\n", NTP_POOL);
+  Serial.printf("NTP sync to %s\n", NTP_POOL);
   configTime(TIME_ZONE, TIME_DST, NTP_POOL); // see config.h
-  while (time(NULL)==0){
+  while (time(NULL)<SECONDS_FROM_1970_TO_2000){
     Serial.print(".");
     delay(1000);
   }
-  Serial.printf("NTP time %d\n",time(NULL));
+  Serial.printf("\nNTP synced\n");
+  oled_time("NTP", time(NULL), NTP_POOL);
 }
 
 void loop() {
   // get time for internal clock, which is NTP synced
-  uint32_t unixtime = (uint32_t) time(NULL);
+  time_t unixtime = time(NULL);
 
-  if (update_rtc(ds1307, unixtime)){
+  if (update_rtc(ds1307, unixtime, "DS1307")){
     // sucesful update: DS1307/DS3231
-    oled_time("RTC", ds1307.now(), "DS1307/DS3231");
-  } else if(update_rtc(pcf8523, unixtime)){
-    // sucesful update: PCF8523/PCF8563(?)
-    oled_time("RTC", pcf8523.now(), "PCF8523/PCF8563");
+    oled_time("RTC", ds1307.now(), "DS1307");
+  } else if(update_rtc(pcf8523, unixtime, "PCF8523")){
+    // sucesful update: PCF8523
+    oled_time("RTC", pcf8523.now(), "PCF8523");
+  } else if(update_rtc(pcf8523, unixtime, "PCF8523")){
+    // sucesful update: PCF8563
+    oled_time("RTC", pcf8523.now(), "PCF8563");
   } else {
     // no RTC found/updated, report NTC time
-    oled_time("NTP", DateTime(unixtime), NTP_POOL);
+    oled_time("SYS", unixtime, NTP_POOL);
   }
 
   delay(6000); // 60 secs
 }
 
-bool update_rtc(RTC_DS1307 &rtc, uint32_t unixtime){
-  const char fmt[] = "RTC DS1307 %s %d\n";
+bool update_rtc(RTC &rtc, time_t unixtime, const char* name){
+  const char fmt[] = "RTC %s %s %d\n";
+#ifdef DEBUG
+ #define debug(s,d) Serial.printf(fmt,name,s,d)
+#else
+ #define debug(s,d) //skip this line
+#endif
 
   if(!rtc.isrunning()){
-    debug(fmt,"not found",-1);
+    debug("not found", -1);
     return false;
   }
 
-  DateTime now = rtc.now();
-  if(now.unixtime()==unixtime){
-    debug(fmt,"on sync",0);
+  time_t now = rtc.now();
+  if(now==unixtime){
+    debug("on sync", 0);
     return true;
   }
 
-  debug(fmt,"now",now.unixtime());
-  debug(fmt,"off by",now.unixtime()-unixtime);
-  rtc.adjust(DateTime(unixtime));
+  debug("now", now);
+  debug("off by", now-unixtime);
+  rtc.adjust(unixtime);
   now = rtc.now();
-  debug(fmt,"off by",now.unixtime()-unixtime);
+  debug("off by", now-unixtime);
 
   // should take way less than 1s to update
-  return now.unixtime()==unixtime;
+  return now==unixtime;
 }
-
-bool update_rtc(RTC_PCF8523 &rtc, uint32_t unixtime){
-  const char fmt[] = "RTC PCF8523 %s %d\n";
-
-  if(!rtc.initialized()){
-    debug(fmt,"not found",-1);
-    return false;
-  }
-
-  DateTime now = rtc.now();
-  if(now.unixtime()==unixtime){
-    debug(fmt,"on sync",0);
-    return true;
-  }
-
-  debug(fmt,"now",now.unixtime());
-  debug(fmt,"off by",now.unixtime()-unixtime);
-  rtc.adjust(DateTime(unixtime));
-  now = rtc.now();
-  debug(fmt,"off by",now.unixtime()-unixtime);
-
-  // should take way less than 1s to update
-  return now.unixtime()==unixtime;
-}
-
 
 void oled_wifi(){
   display.clear();
@@ -150,11 +131,10 @@ void oled_wifi(){
   display.display();
 }
 
-void oled_time(const char* title, DateTime now, const char* msg) {
+void oled_time(const char* title, time_t now, const char* msg) {
   // serial message
-  Serial.printf("%s %d %s\n",title, now.unixtime(), msg);
+  Serial.printf("%s %d %s\n",title, now, msg);
 
-  static char buffer[24];
   display.clear();
   display.setTextAlignment(TEXT_ALIGN_CENTER);
   display.setFont(ArialMT_Plain_24);
@@ -162,9 +142,12 @@ void oled_time(const char* title, DateTime now, const char* msg) {
 
   // date and time
   display.setFont(ArialMT_Plain_10);
-  sprintf(buffer, "%04d-%02d-%02d", now.year(), now.month(), now.day());
+  const uint8_t chlen = 24;
+  static char buffer[chlen];
+  struct tm *timeinfo = localtime(&now);
+  strftime(buffer, chlen, "%F", timeinfo);
   display.drawString(64, 42, buffer);
-  sprintf(buffer, "%02d:%02d:%02d", now.hour(), now.minute(), now.second());
+  strftime(buffer, chlen, "%T", timeinfo);
   display.drawString(64, 54, buffer);
 
   // write the buffer to the display

--- a/src/ESPntp2rtc.ino
+++ b/src/ESPntp2rtc.ino
@@ -70,8 +70,11 @@ void loop() {
   time_t unixtime = time(NULL);
 
   if (update_rtc(ds1307, unixtime, "DS1307")){
-    // sucesful update: DS1307/DS3231
+    // sucesful update: DS1307
     oled_time("RTC", ds1307.now(), "DS1307");
+  } else if (update_rtc(ds3231, unixtime, "DS3231")){
+      // sucesful update: DS3231
+      oled_time("RTC", ds3231.now(), "DS3231");
   } else if(update_rtc(pcf8523, unixtime, "PCF8523")){
     // sucesful update: PCF8523
     oled_time("RTC", pcf8523.now(), "PCF8523");
@@ -79,8 +82,8 @@ void loop() {
     // sucesful update: PCF8563
     oled_time("RTC", pcf8523.now(), "PCF8563");
   } else {
-    // no RTC found/updated, report NTC time
-    oled_time("SYS", unixtime, NTP_POOL);
+    // no RTC found/updated, report SYSTEM time
+    oled_time("SYS", unixtime, "");
   }
 
   delay(6000); // 60 secs

--- a/src/ESPntp2rtc.ino
+++ b/src/ESPntp2rtc.ino
@@ -30,7 +30,7 @@ RTC pcf8563(rtc_t::PCF8563);
 
 void setup() {
   Serial.begin(115200);
-  Serial.printf("/nBooted");
+  Serial.printf("\nBooted\n");
 
 //Wire.begin(SDA, SCL); // not needed, SSD1306Wire->connect() calls Wire.begin(SDA, SCL)
   display.init();
@@ -78,9 +78,9 @@ void loop() {
   } else if(update_rtc(pcf8523, unixtime, "PCF8523")){
     // sucesful update: PCF8523
     oled_time("RTC", pcf8523.now(), "PCF8523");
-  } else if(update_rtc(pcf8523, unixtime, "PCF8523")){
+  } else if(update_rtc(pcf8563, unixtime, "PCF8563")){
     // sucesful update: PCF8563
-    oled_time("RTC", pcf8523.now(), "PCF8563");
+    oled_time("RTC", pcf8563.now(), "PCF8563");
   } else {
     // no RTC found/updated, report SYSTEM time
     oled_time("SYS", unixtime, "");

--- a/src/RTC.cpp
+++ b/src/RTC.cpp
@@ -1,0 +1,138 @@
+#include <Arduino.h>
+#include <Wire.h>
+#include <time.h>
+#include <assert.h>
+#include "RTC.h"
+
+#define DS1307_ADDRESS    0x68
+#define DS1307_SEC_REG    0x00
+
+#define DS3231_ADDRESS    0x68
+#define DS3231_SEC_REG    0x00
+
+#define PCF8523_ADDRESS   0x68
+#define PCF8523_SEC_REG   0x03
+
+#define PCF8563_ADDRESS   0x51
+#define PCF8563_SEC_REG   0x02
+
+// tm_year = years since 1900
+const uint16_t epoch = 1900, y2k = 2000 - epoch;
+
+RTC::RTC(const rtc_t& rtc) {
+  rtc_id = rtc;
+  switch (rtc_id) {
+    case rtc_t::DS1307:
+      address = DS1307_ADDRESS;
+      sec_reg = DS1307_SEC_REG;
+      break;
+    case rtc_t::DS3231:
+      address = DS3231_ADDRESS;
+      sec_reg = DS3231_SEC_REG;
+      break;
+    case rtc_t::PCF8523:
+      address = PCF8523_ADDRESS;
+      sec_reg = PCF8523_SEC_REG;
+      break;
+    case rtc_t::PCF8563:
+      address = PCF8563_ADDRESS;
+      sec_reg = PCF8563_SEC_REG;
+      break;
+    default:
+      Serial.printf("RTC not implemented\n");
+      delay(1000);
+      assert(false);
+  }
+}
+
+boolean RTC::isrunning() {
+  Wire.beginTransmission(address);
+  Wire.write(sec_reg+6);
+  Wire.endTransmission();
+
+  Wire.requestFrom(address, (uint8_t)1);
+  uint8_t bcd = Wire.read();
+//Serial.printf("RTC year %4d, bcd %3d, found %s\n",
+//  bcd2bin(bcd)+2000, bcd, (bcd != 0xFF)?"T":"F");
+  return (bcd != 0xFF);
+}
+
+void RTC::adjust(const time_t &now) {
+  struct tm *timeinfo = localtime(&now);
+  if(mktime(timeinfo)!=now){
+    Serial.printf("ERROR: localtime/mktime missmatch");
+    printftime(timeinfo, "  localtime");
+    printftime(mktime(timeinfo), "  mktime");
+    return;
+  }
+
+  Wire.beginTransmission(address);
+  Wire.write(sec_reg);
+  switch (rtc_id) {
+    case rtc_t::DS1307:
+    case rtc_t::DS3231:
+      Wire.write(bin2bcd(timeinfo->tm_sec));
+      Wire.write(bin2bcd(timeinfo->tm_min));
+      Wire.write(bin2bcd(timeinfo->tm_hour));
+      Wire.write(bin2bcd(0)); // skip day of the week
+      Wire.write(bin2bcd(timeinfo->tm_mday));
+      Wire.write(bin2bcd(timeinfo->tm_mon));
+      Wire.write(bin2bcd(timeinfo->tm_year - y2k));
+      break;
+    case rtc_t::PCF8523:
+    case rtc_t::PCF8563:
+      Wire.write(bin2bcd(timeinfo->tm_sec));
+      Wire.write(bin2bcd(timeinfo->tm_min));
+      Wire.write(bin2bcd(timeinfo->tm_hour));
+      Wire.write(bin2bcd(timeinfo->tm_mday));
+      Wire.write(bin2bcd(0)); // skip day of the week
+      Wire.write(bin2bcd(timeinfo->tm_mon));
+      Wire.write(bin2bcd(timeinfo->tm_year - y2k));
+      break;
+  }
+  Wire.endTransmission();
+}
+
+time_t RTC::now() {
+  time_t now = time(NULL);
+  struct tm *timeinfo = localtime(&now);
+  if(mktime(timeinfo)!=now){
+    Serial.printf("ERROR: localtime/mktime missmatch");
+    printftime(timeinfo, "  localtime");
+    printftime(mktime(timeinfo), "  mktime");
+    return (time_t)0;
+  }
+
+  Wire.beginTransmission(address);
+  Wire.write(sec_reg);
+  Wire.endTransmission();
+
+  Wire.requestFrom(address, (uint8_t)7);
+  switch (rtc_id) {
+    case rtc_t::DS1307:
+    case rtc_t::DS3231:
+      timeinfo->tm_sec = bcd2bin(Wire.read() & 0x7F);
+      timeinfo->tm_min = bcd2bin(Wire.read() & 0x7F);
+      timeinfo->tm_hour= bcd2bin(Wire.read() & 0x3F);
+      Wire.read(); // skip day of the week
+      timeinfo->tm_mday= bcd2bin(Wire.read() & 0x3F);
+      timeinfo->tm_mon = bcd2bin(Wire.read() & 0x1F);
+      timeinfo->tm_year= bcd2bin(Wire.read()) + y2k;
+      break;
+    case rtc_t::PCF8523:
+    case rtc_t::PCF8563:
+      timeinfo->tm_sec = bcd2bin(Wire.read() & 0x7F);
+      timeinfo->tm_min = bcd2bin(Wire.read() & 0x7F);
+      timeinfo->tm_hour= bcd2bin(Wire.read() & 0x3F);
+      timeinfo->tm_mday= bcd2bin(Wire.read() & 0x3F);
+      Wire.read(); // skip day of the week
+      timeinfo->tm_mon = bcd2bin(Wire.read() & 0x1F);
+      timeinfo->tm_year= bcd2bin(Wire.read()) + y2k;
+      break;
+  }
+#ifdef DEBUG
+  printftime(now, "  SYS");
+  printftime(timeinfo, "  RTC");
+#endif
+  return mktime(timeinfo);
+}

--- a/src/RTC.cpp
+++ b/src/RTC.cpp
@@ -61,7 +61,12 @@ boolean RTC::isrunning() {
 
 void RTC::adjust(const struct tm *timeinfo) {
   Wire.beginTransmission(address);
-  Wire.write(sec_reg);
+  // wipe control/status registers
+  Wire.write((uint8_t)0);
+  for(uint8_t reg=0x00; reg<sec_reg; reg++){
+    Wire.write((uint8_t) 0x0);
+  }
+  // write time/date registers
   switch (rtc_id) {
     case rtc_t::DS1307:
     case rtc_t::DS3231:

--- a/src/RTC.h
+++ b/src/RTC.h
@@ -1,0 +1,37 @@
+#ifndef _RTC_H_
+#define _RTC_H_
+
+#include <Arduino.h>
+#include <time.h>
+
+enum class rtc_t {DS1307, DS3231, PCF8523, PCF8563};
+
+class RTC {
+public:
+    RTC(const rtc_t &rtc);
+    boolean isrunning();
+    void adjust(const time_t &now);
+    time_t now();
+
+    // utility functions
+    static uint8_t bcd2bin (uint8_t val) { return val - 6 * (val >> 4); }
+    static uint8_t bin2bcd (uint8_t val) { return val + 6 * (val / 10); }
+    static void printftime (const struct tm *timeinfo, const char *title=""){
+      const uint8_t chlen = 24;
+      static char buffer[chlen];
+      strftime(buffer, chlen, "%F %T", timeinfo);
+      Serial.printf("%s %s\n", title, buffer);
+    }
+    static void printftime (const time_t &now, const char *title=""){
+      struct tm *timeinfo = localtime(&now);
+      printftime(timeinfo, title);
+    }
+
+  protected:
+    rtc_t rtc_id;
+    uint8_t address, sec_reg;
+};
+
+
+
+#endif // _RTC_H_

--- a/src/RTC.h
+++ b/src/RTC.h
@@ -7,29 +7,33 @@
 enum class rtc_t {DS1307, DS3231, PCF8523, PCF8563};
 
 class RTC {
-public:
+  public:
     RTC(const rtc_t &rtc);
     boolean isrunning();
+    void adjust(const struct tm *timeinfo);
     void adjust(const time_t &now);
     time_t now();
-
-    // utility functions
-    static uint8_t bcd2bin (uint8_t val) { return val - 6 * (val >> 4); }
-    static uint8_t bin2bcd (uint8_t val) { return val + 6 * (val / 10); }
-    static void printftime (const struct tm *timeinfo, const char *title=""){
-      const uint8_t chlen = 24;
-      static char buffer[chlen];
-      strftime(buffer, chlen, "%F %T", timeinfo);
-      Serial.printf("%s %s\n", title, buffer);
-    }
-    static void printftime (const time_t &now, const char *title=""){
-      struct tm *timeinfo = localtime(&now);
-      printftime(timeinfo, title);
-    }
+    struct tm *timeinfo();
 
   protected:
     rtc_t rtc_id;
     uint8_t address, sec_reg;
+    
+    // utility functions
+    static uint8_t bcd2bin (uint8_t val) { return val - 6 * (val >> 4); }
+    static uint8_t bin2bcd (uint8_t val) { return val + 6 * (val / 10); }
+
+    // debug printout
+    static void printftime (const struct tm *timeinfo, const char *title="", const char *msg=""){
+      const uint8_t chlen = 24;
+      static char buffer[chlen];
+      strftime(buffer, chlen, "%F %T", timeinfo);
+      Serial.printf("%s %s %s\n", title, buffer, msg);
+    }
+    static void printftime (const time_t &now, const char *title="", const char *msg=""){
+      struct tm *timeinfo = localtime(&now);
+      printftime(timeinfo, title, msg);
+    }
 };
 
 


### PR DESCRIPTION
The C/C++ time library provide the functionality currently provided by the DateTime class.
With the time/date management out of the way,
it possible to implement a small RTC library which only deals with the RTC setup on a esp8266 or a esp32:
- check if the RTC is present
- read the RTC time/date registers
- write the RTC time/date registers

Unfortunately `mktime` on the current release of esp8266/Arduino core is [broken][].
It is already fixed on the github version and should be released at some point in the future. 
Until then, the development and testing for the esp8266 needs to relay on the DateTime class (provided by `RTClib` [JeeLab's][] or [Adafruit][] version). Other option is `TimeLib` by [PaulStoffregen][], which provides similar functionality to the C/C++ time library.

This PR provides an easy way to keep the DateTime (`master` branch) and C/C++ (`ctime` branch) versions of the code in sync.

[JeeLab's]: https://github.com/jcw/rtclib
[Adafruit]: https://github.com/adafruit/RTClib
[PaulStoffregen]: https://github.com/PaulStoffregen/Time

[broken]: https://github.com/esp8266/Arduino/issues/1745